### PR TITLE
Protect /user/ endpoints

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -25,7 +25,7 @@ uwsgi = "*"
 django-filter = "*"
 django-labs-accounts = "*"
 django-debug-toolbar = "*"
-
+ipython = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "79b4232d3222940534e1a9803330bbbe1666a30926695d0f12b75f34ba14d4ff"
+            "sha256": "aadba21f38a7ebcd74211fcde8604c9cafc795de7a81e5115168a03c5553c8f2"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,12 +16,27 @@
         ]
     },
     "default": {
+        "appnope": {
+            "hashes": [
+                "sha256:5b26757dc6f79a3b7dc9fab95359328d5747fcb2409d331ea66d0272b90ab2a0",
+                "sha256:8b995ffe925347a2138d7ac0fe77155e4311a0ea6d6da4f5128fe4b3cbe5ed71"
+            ],
+            "markers": "sys_platform == 'darwin'",
+            "version": "==0.1.0"
+        },
         "asgiref": {
             "hashes": [
                 "sha256:7e06d934a7718bf3975acbf87780ba678957b87c7adc056f13b6215d610695a0",
                 "sha256:ea448f92fc35a0ef4b1508f53a04c4670255a3f33d22a81c8fc9c872036adbe5"
             ],
             "version": "==3.2.3"
+        },
+        "backcall": {
+            "hashes": [
+                "sha256:38ecd85be2c1e78f77fd91700c76e14667dc21e2713b63876c0eb901196e01e4",
+                "sha256:bbbf4b1e5cd2bdb08f915895b51081c041bac22394fdfcfdfbe9f14b77c08bf2"
+            ],
+            "version": "==0.1.0"
         },
         "certifi": {
             "hashes": [
@@ -36,6 +51,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce",
+                "sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d"
+            ],
+            "version": "==4.4.1"
         },
         "dj-database-url": {
             "hashes": [
@@ -100,6 +122,28 @@
             ],
             "version": "==2.8"
         },
+        "ipython": {
+            "hashes": [
+                "sha256:0f4bcf18293fb666df8511feec0403bdb7e061a5842ea6e88a3177b0ceb34ead",
+                "sha256:387686dd7fc9caf29d2fddcf3116c4b07a11d9025701d220c589a430b0171d8a"
+            ],
+            "index": "pypi",
+            "version": "==7.11.1"
+        },
+        "ipython-genutils": {
+            "hashes": [
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
+            ],
+            "version": "==0.2.0"
+        },
+        "jedi": {
+            "hashes": [
+                "sha256:b4f4052551025c6b0b0b193b29a6ff7bdb74c52450631206c262aef9f7159ad2",
+                "sha256:d5c871cb9360b414f981e7072c52c33258d598305280fef91c6cae34739d65d5"
+            ],
+            "version": "==0.16.0"
+        },
         "mysqlclient": {
             "hashes": [
                 "sha256:4c82187dd6ab3607150fbb1fa5ef4643118f3da122b8ba31c3149ddd9cf0cb39",
@@ -116,6 +160,49 @@
                 "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
             ],
             "version": "==3.1.0"
+        },
+        "parso": {
+            "hashes": [
+                "sha256:1376bdc8cb81377ca481976933773295218a2df47d3e1182ba76d372b1acb128",
+                "sha256:597f36de5102a8db05ffdf7ecdc761838b86565a4a111604c6e78beaedf1b045"
+            ],
+            "version": "==0.6.0"
+        },
+        "pexpect": {
+            "hashes": [
+                "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
+                "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"
+            ],
+            "markers": "sys_platform != 'win32'",
+            "version": "==4.8.0"
+        },
+        "pickleshare": {
+            "hashes": [
+                "sha256:87683d47965c1da65cdacaf31c8441d12b8044cdec9aca500cd78fc2c683afca",
+                "sha256:9649af414d74d4df115d5d718f82acb59c9d418196b7b4290ed47a12ce62df56"
+            ],
+            "version": "==0.7.5"
+        },
+        "prompt-toolkit": {
+            "hashes": [
+                "sha256:a402e9bf468b63314e37460b68ba68243d55b2f8c4d0192f85a019af3945050e",
+                "sha256:c93e53af97f630f12f5f62a3274e79527936ed466f038953dfa379d4941f651a"
+            ],
+            "version": "==3.0.3"
+        },
+        "ptyprocess": {
+            "hashes": [
+                "sha256:923f299cc5ad920c68f2bc0bc98b75b9f838b93b599941a6b63ddbc2476394c0",
+                "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"
+            ],
+            "version": "==0.6.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b",
+                "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"
+            ],
+            "version": "==2.5.2"
         },
         "pytz": {
             "hashes": [
@@ -163,12 +250,26 @@
             "index": "pypi",
             "version": "==0.14.1"
         },
+        "six": {
+            "hashes": [
+                "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a",
+                "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"
+            ],
+            "version": "==1.14.0"
+        },
         "sqlparse": {
             "hashes": [
                 "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
                 "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
             ],
             "version": "==0.3.0"
+        },
+        "traitlets": {
+            "hashes": [
+                "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44",
+                "sha256:d023ee369ddd2763310e4c3eae1ff649689440d4ae59d7485eb4cfbbe3e359f7"
+            ],
+            "version": "==4.3.3"
         },
         "uritemplate": {
             "hashes": [
@@ -191,6 +292,13 @@
             ],
             "index": "pypi",
             "version": "==2.0.18"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:8fd29383f539be45b20bd4df0dc29c20ba48654a41e661925e612311e9f3c603",
+                "sha256:f28b3e8a6483e5d49e7f8949ac1a78314e740333ae305b4ba5defd3e74fb37a8"
+            ],
+            "version": "==0.1.8"
         }
     },
     "develop": {

--- a/gsr_booking/serializers.py
+++ b/gsr_booking/serializers.py
@@ -52,22 +52,7 @@ class GroupField(serializers.RelatedField):
 
 
 class UserSerializer(serializers.ModelSerializer):
-    booking_groups = serializers.SerializerMethodField()
-
-    def get_booking_groups(self, obj):
-        result = []
-        for membership in GroupMembership.objects.filter(accepted=True, user=obj):
-            result.append(
-                {
-                    "name": membership.group.name,
-                    "id": membership.group.id,
-                    "color": membership.group.color,
-                    "pennkey_allow": membership.pennkey_allow,
-                    "notifications": membership.notifications,
-                }
-            )
-
-        return result
+    booking_groups = GroupMembershipSerializer(source="memberships", many=True, read_only=True)
 
     class Meta:
         model = User

--- a/gsr_booking/tests.py
+++ b/gsr_booking/tests.py
@@ -88,7 +88,7 @@ class UserViewTestCase(TestCase):
         self.assertEqual(1, len(response.data))
 
     def test_no_cross_visibility_without_shared_group(self):
-        group2 = Group.objects.create(owner=self.user2, name="g2", color="red")
+        Group.objects.create(owner=self.user2, name="g2", color="red")
         response = self.client.get("/users/")
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, len(response.data), response.data)

--- a/gsr_booking/tests.py
+++ b/gsr_booking/tests.py
@@ -87,6 +87,22 @@ class UserViewTestCase(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(1, len(response.data))
 
+    def test_no_cross_visibility_without_shared_group(self):
+        group2 = Group.objects.create(owner=self.user2, name="g2", color="red")
+        response = self.client.get("/users/")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, len(response.data), response.data)
+        self.assertEqual(0, len(response.data[1]["booking_groups"]), response.data)
+
+    def test_visibility_within_group(self):
+        Group.objects.create(owner=self.user2, name="g2", color="red")
+        GroupMembership.objects.create(user=self.user2, group=self.group, accepted=True)
+        response = self.client.get("/users/")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, len(response.data), response.data)
+        self.assertEqual(1, len(response.data[1]["booking_groups"]), response.data)
+        self.assertEqual("g1", response.data[1]["booking_groups"][0]["group"]["name"])
+
 
 class MembershipViewTestCase(TestCase):
     def setUp(self):

--- a/gsr_booking/tests.py
+++ b/gsr_booking/tests.py
@@ -101,7 +101,7 @@ class UserViewTestCase(TestCase):
         self.assertEqual(200, response.status_code)
         self.assertEqual(2, len(response.data), response.data)
         self.assertEqual(1, len(response.data[1]["booking_groups"]), response.data)
-        self.assertEqual("g1", response.data[1]["booking_groups"][0]["group"]["name"])
+        self.assertEqual("g1", response.data[1]["booking_groups"][0]["group"])
 
 
 class MembershipViewTestCase(TestCase):

--- a/gsr_booking/views.py
+++ b/gsr_booking/views.py
@@ -65,7 +65,10 @@ class UserViewSet(viewsets.ReadOnlyModelViewSet):
         user = get_object_or_404(User, username=username)
         return Response(
             GroupMembershipSerializer(
-                GroupMembership.objects.filter(user=user, accepted=False), many=True
+                GroupMembership.objects.filter(
+                    user=user, accepted=False, group__in=self.request.user.booking_groups.all()
+                ),
+                many=True,
             ).data
         )
 


### PR DESCRIPTION
This PR makes it so users can only see details of other users that they should be allowed to see.

Previously, you could look up all groups any user was a part of just by hitting the `/users` endpoint. Now, when you hit that endpoint, you will only see groups for users which you are also a member of.